### PR TITLE
Map Bugfix

### DIFF
--- a/app/src/main/java/com/example/snailscurlup/ui/map/MapFragment.java
+++ b/app/src/main/java/com/example/snailscurlup/ui/map/MapFragment.java
@@ -132,7 +132,7 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
         // Get QR Code markers from database
         // TODO: In the future, do this based on proximity (not ALL of them)
-        db.collection("QR")
+        db.collection("QRMapMarkers")
                 .get()
                 .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                     @Override


### PR DESCRIPTION
Map was using an old collection in the table we aren't updating anymore (`QR`), not the new one (`QRMapMarkers`). Fixed that.